### PR TITLE
Fixes a clang static analyzer issue

### DIFF
--- a/ulid_uint128.hh
+++ b/ulid_uint128.hh
@@ -203,7 +203,7 @@ void EncodeNowRand(ULID& ulid) {
  * Create will create a ULID with a timestamp and a generator.
  * */
 ULID Create(time_t timestamp, const std::function<uint8_t()>& rng) {
-	ULID ulid;
+	ULID ulid = 0;
 	Encode(timestamp, rng, ulid);
 	return ulid;
 }
@@ -212,7 +212,7 @@ ULID Create(time_t timestamp, const std::function<uint8_t()>& rng) {
  * CreateNowRand:EncodeNowRand = Create:Encode.
  * */
 ULID CreateNowRand() {
-	ULID ulid;
+	ULID ulid = 0;
 	EncodeNowRand(ulid);
 	return ulid;
 }


### PR DESCRIPTION
`EncodeTime` preserves the present bit-pattern of the `ULID` being passed (as it should).
Because `__uint128_t` does not have a constructor, `Create` and `CreateNowRandom` were passing the reference to an un-initialised value — which the clang static analyzer complains about:
```
ulid_uint128.hh:45:19: The left operand of '&' is a garbage value

        ulid = t | (ulid & mask);
                    ~~~~ ^
```
The commit in this PR fixes the issue by initialising the values being passed by reference.