### PR TITLE
- compile fix for msvc 14.24.28314

### DIFF
--- a/ulid_struct.hh
+++ b/ulid_struct.hh
@@ -8,6 +8,12 @@
 #include <random>
 #include <vector>
 
+#if _MSC_VER > 0
+typedef uint32_t rand_t;
+# else
+typedef uint8_t rand_t;
+#endif
+
 namespace ulid {
 
 /**
@@ -310,7 +316,7 @@ inline void EncodeEntropyRand(ULID& ulid) {
 	ulid.data[15] = (std::rand() * 255ull) / RAND_MAX;
 }
 
-static std::uniform_int_distribution<uint32_t> Distribution_0_255(0, 255);
+static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);
 
 /**
  * EncodeEntropyMt19937 will encode a ulid using std::mt19937

--- a/ulid_struct.hh
+++ b/ulid_struct.hh
@@ -310,7 +310,7 @@ inline void EncodeEntropyRand(ULID& ulid) {
 	ulid.data[15] = (std::rand() * 255ull) / RAND_MAX;
 }
 
-static std::uniform_int_distribution<uint8_t> Distribution_0_255(0, 255);
+static std::uniform_int_distribution<uint32_t> Distribution_0_255(0, 255);
 
 /**
  * EncodeEntropyMt19937 will encode a ulid using std::mt19937

--- a/ulid_struct.hh
+++ b/ulid_struct.hh
@@ -304,16 +304,16 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid) {
  * std::rand returns values in [0, RAND_MAX]
  * */
 inline void EncodeEntropyRand(ULID& ulid) {
-	ulid.data[6] = (std::rand() * 255ull) / RAND_MAX;
-	ulid.data[7] = (std::rand() * 255ull) / RAND_MAX;
-	ulid.data[8] = (std::rand() * 255ull) / RAND_MAX;
-	ulid.data[9] = (std::rand() * 255ull) / RAND_MAX;
-	ulid.data[10] = (std::rand() * 255ull) / RAND_MAX;
-	ulid.data[11] = (std::rand() * 255ull) / RAND_MAX;
-	ulid.data[12] = (std::rand() * 255ull) / RAND_MAX;
-	ulid.data[13] = (std::rand() * 255ull) / RAND_MAX;
-	ulid.data[14] = (std::rand() * 255ull) / RAND_MAX;
-	ulid.data[15] = (std::rand() * 255ull) / RAND_MAX;
+	ulid.data[6] = (uint8_t)(std::rand() * 255ull) / RAND_MAX;
+	ulid.data[7] = (uint8_t)(std::rand() * 255ull) / RAND_MAX;
+	ulid.data[8] = (uint8_t)(std::rand() * 255ull) / RAND_MAX;
+	ulid.data[9] = (uint8_t)(std::rand() * 255ull) / RAND_MAX;
+	ulid.data[10] = (uint8_t)(std::rand() * 255ull) / RAND_MAX;
+	ulid.data[11] = (uint8_t)(std::rand() * 255ull) / RAND_MAX;
+	ulid.data[12] = (uint8_t)(std::rand() * 255ull) / RAND_MAX;
+	ulid.data[13] = (uint8_t)(std::rand() * 255ull) / RAND_MAX;
+	ulid.data[14] = (uint8_t)(std::rand() * 255ull) / RAND_MAX;
+	ulid.data[15] = (uint8_t)(std::rand() * 255ull) / RAND_MAX;
 }
 
 static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);

--- a/ulid_uint128.hh
+++ b/ulid_uint128.hh
@@ -8,7 +8,7 @@
 #include <random>
 #include <vector>
 
-#if #if _MSC_VER > 0
+#if _MSC_VER > 0
 typedef uint32_t rand_t;
 # else
 typedef uint8_t rand_t;

--- a/ulid_uint128.hh
+++ b/ulid_uint128.hh
@@ -142,7 +142,7 @@ inline void EncodeEntropyRand(ULID& ulid) {
 	ulid |= e;
 }
 
-static std::uniform_int_distribution<uint8_t> Distribution_0_255(0, 255);
+static std::uniform_int_distribution<uint32_t> Distribution_0_255(0, 255);
 
 /**
  * EncodeEntropyMt19937 will encode a ulid using std::mt19937

--- a/ulid_uint128.hh
+++ b/ulid_uint128.hh
@@ -8,6 +8,12 @@
 #include <random>
 #include <vector>
 
+#if #if _MSC_VER > 0
+typedef uint32_t rand_t;
+# else
+typedef uint8_t rand_t;
+#endif
+
 namespace ulid {
 
 /**
@@ -142,7 +148,7 @@ inline void EncodeEntropyRand(ULID& ulid) {
 	ulid |= e;
 }
 
-static std::uniform_int_distribution<uint32_t> Distribution_0_255(0, 255);
+static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);
 
 /**
  * EncodeEntropyMt19937 will encode a ulid using std::mt19937


### PR DESCRIPTION
MSVC\14.24.28314\include\random(1907,1): error C2338: note: char, signed char, unsigned char, char8_t, int8_t, and uint8_t are not allowed

Wonder if you are interested in supporting MSVC 14.24.28314 compiler.. not sure what other version of MSVC work or not, this is running on a GitHub action an I haven't tested it on windows myself yet!

Changing to uint32_t fixes the compiler error, I don't think this should cause any problems with the actual generated ulid? 

The uint128 implementation is just bit-wise or into a larger type anyway, so all the 0's in the upper 3 bytes won't make any difference, and this shouldn't affect performance either because it was already doing bitwise or of 2 different sized integer types.. in fact maybe you can improve performance by using the same sized integer (128) when doing the or?

the struct implementation is assigning 32bit values to 8bit array index, as we are in 0-255 should make no difference to result, maybe might affect performance, assigning the uint32 into a uint8? 

