### PR TITLE
Set visibility of bazel library to public

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,7 @@ cc_library(
 cc_library(
     name = "ulid_struct",
     srcs = ["src/ulid_struct.hh"],
+    visibility = ["//visibility:public"],
 )
 
 # benchmarks

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 cc_library(
     name = "ulid_uint128",
     srcs = ["src/ulid_uint128.hh"],
-    visibility = "//visibility:public",
+    visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 cc_library(
     name = "ulid_uint128",
     srcs = ["src/ulid_uint128.hh"],
+    visibility = "//visibility:public",
 )
 
 cc_library(


### PR DESCRIPTION
# Description
The default bazel visiblity for libraries is private. By setting it to public, users of the library can more easily integration/pull ulid into their own projects.

`WORKSPACE` in user's project
```bzl
git_repository(
    name = "ulid",
    commit = "3a46362db2c0f5fece10e59a52bdefbf7eec0877",
    remote = "https://github.com/suyash/ulid/",
)
```

`BUILD.bazel` in user's project
```bzl
cc_binary(
    name = "my_project",
    hdrs = glob(["include/*.hpp"]),
    srcs = glob(["src/*.cpp"]),
    deps = [
        "@ulid//:ulid_uint128",
         ...
    ],
)

```